### PR TITLE
Disallow folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Rule | Meaning
 `components/*/utils` | ✅&nbsp;&nbsp;The directory `components` is accepted.<br/> ✅&nbsp;&nbsp;Any *first level* nested directory is accepted.<br/> ✅&nbsp;&nbsp;The *second level* nested directory `utils` is accepted.<br/> ❌&nbsp;&nbsp;Any other *second level* nested directory is not accepted.
 `legacy/**` | ✅&nbsp;&nbsp;The directory `legacy` is accepted.<br/> ✅&nbsp;&nbsp;Any nested directory on *any level* is accepted.
 `components/*/legacy/**` | ✅&nbsp;&nbsp;The directory `components` is accepted.<br/> ✅&nbsp;&nbsp;Any *first level* nested directory is accepted.<br/> ✅&nbsp;&nbsp;The *second level* nested directory `legacy` is accepted.<br/> ❌&nbsp;&nbsp;Any other *second level* nested directory is not accepted.<br/> ✅&nbsp;&nbsp;Any nested directory on *any level* inside of *legacy* directory is accepted.
+`!pages/*` | ❌&nbsp;&nbsp;Any nested directory inside `pages` is not accepted.
 
 ⚠️ A rule like `components/*/utils` automatically make the `components` and `components/*` rules work. So, no need to specify a rule for every level directory. You need to specify the deepest path.
 

--- a/__tests__/runLinter.js
+++ b/__tests__/runLinter.js
@@ -196,3 +196,22 @@ test('should not accept files with * and ** in the same rule', () => {
     'folderslint: 2 error(s) found'
   )
 })
+
+test('should not accept files with ! (negation) in the beginning of the rule ', () => {
+  parseConfig.mockReturnValue({
+    root: 'src',
+    rules: ['!pages/*'],
+  })
+
+  runLinter([
+    'cwd/src/pages/components',
+  ])
+
+  expect(process.exit).toHaveBeenLastCalledWith(1)
+
+  expect(console.log).toHaveBeenNthCalledWith(
+    1,
+    chalk.underline('cwd/src/pages/components')
+  )
+  expect(console.log).toHaveBeenNthCalledWith(2, ERROR_MESSAGE)
+})

--- a/__tests__/runLinter.js
+++ b/__tests__/runLinter.js
@@ -203,9 +203,7 @@ test('should not accept files with ! (negation) in the beginning of the rule ', 
     rules: ['!pages/*'],
   })
 
-  runLinter([
-    'cwd/src/pages/components',
-  ])
+  runLinter(['cwd/src/pages/components'])
 
   expect(process.exit).toHaveBeenLastCalledWith(1)
 

--- a/src/parseConfig.js
+++ b/src/parseConfig.js
@@ -19,6 +19,12 @@ const validateParsedConfig = (config) => {
       console.error('A rule can have ** only at the end')
       process.exit(1)
     }
+
+    if (rule.includes("!") && rule.startsWith("!") && rule.split("!").length > 2) {
+      console.error(`Invalid rule: ${rule}`)
+      console.error('A rule can have at most one ! at the beginning')
+      process.exit(1)
+    }
   })
   return config
 }

--- a/src/parseConfig.js
+++ b/src/parseConfig.js
@@ -20,7 +20,11 @@ const validateParsedConfig = (config) => {
       process.exit(1)
     }
 
-    if (rule.includes("!") && rule.startsWith("!") && rule.split("!").length > 2) {
+    if (
+      rule.includes('!') &&
+      rule.startsWith('!') &&
+      rule.split('!').length > 2
+    ) {
       console.error(`Invalid rule: ${rule}`)
       console.error('A rule can have at most one ! at the beginning')
       process.exit(1)

--- a/src/rules.js
+++ b/src/rules.js
@@ -30,7 +30,7 @@ const getExtendedRules = (root = '', rules) => {
 const isPathMatchRule = (path, rule) => {
   const splittedPath = path.split('/')
 
-  const isNegation = rule.startsWith("!");
+  const isNegation = rule.startsWith('!')
   const splittedRule = (isNegation ? rule.substring(1) : rule).split('/')
 
   const isValid = splittedPath.reduce((acc, pathPart, i) => {

--- a/src/rules.js
+++ b/src/rules.js
@@ -29,7 +29,9 @@ const getExtendedRules = (root = '', rules) => {
 
 const isPathMatchRule = (path, rule) => {
   const splittedPath = path.split('/')
-  const splittedRule = rule.split('/')
+
+  const isNegation = rule.startsWith("!");
+  const splittedRule = (isNegation ? rule.substring(1) : rule).split('/')
 
   const isValid = splittedPath.reduce((acc, pathPart, i) => {
     const rulePart = splittedRule[i]
@@ -41,14 +43,14 @@ const isPathMatchRule = (path, rule) => {
   }, true)
 
   if (!isValid) {
-    return false
+    return isNegation
   }
 
   if (!rule.includes('**') && splittedPath.length > splittedRule.length) {
-    return false
+    return isNegation
   }
 
-  return true
+  return !isNegation
 }
 
 const checkPath = (path, rules) => {


### PR DESCRIPTION
This PR adds a feature to disallow folder paths by putting an `!` in front of the rule.
Fix #17 